### PR TITLE
Fix splaytree traverse property error

### DIFF
--- a/packages/sdk/src/util/splay_tree.ts
+++ b/packages/sdk/src/util/splay_tree.ts
@@ -435,6 +435,17 @@ export class SplayTree<V> {
     return true;
   }
 
+  /**
+   * `traverse` traverses the tree in order and calls the callback for each node.
+   */
+  public traverse(callback: (node: SplayNode<V>) => void): void {
+    const nodes: Array<SplayNode<V>> = [];
+    this.traverseInorder(this.root!, nodes);
+    for (const node of nodes) {
+      callback(node);
+    }
+  }
+
   private getRightmost(): SplayNode<V> {
     let node = this.root!;
     while (node.hasRight()) {


### PR DESCRIPTION
#### What this PR does / why we need it?
This PR adds a public `traverse` method to the `SplayTree` class. This resolves the TypeScript error "Property 'traverse' does not exist on type 'SplayTree<CRDTTextValue>'", allowing external code to perform an in-order traversal of the tree.

#### Any background context you want to provide?
The `SplayTree` previously only exposed private `traverseInorder` and `traversePostorder` methods. This change provides a public interface for tree traversal, leveraging the existing private implementation.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything

---
<a href="https://cursor.com/background-agent?bcId=bc-596942a3-0475-4ad7-8edb-31ed13b3755d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-596942a3-0475-4ad7-8edb-31ed13b3755d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

